### PR TITLE
Migrate from javax to jakarta

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,14 +26,14 @@
   </properties>
   <dependencies>
     <dependency>
-      <groupId>javax.activation</groupId>
-      <artifactId>activation</artifactId>
-      <version>1.1.1</version>
+      <groupId>jakarta.activation</groupId>
+      <artifactId>jakarta.activation-api</artifactId>
+      <version>2.1.3</version>
     </dependency>
     <dependency>
-      <groupId>javax.xml.bind</groupId>
-      <artifactId>jaxb-api</artifactId>
-      <version>2.4.0-b180830.0359</version>
+      <groupId>jakarta.xml.bind</groupId>
+      <artifactId>jakarta.xml.bind-api</artifactId>
+      <version>4.0.2</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/src/main/java/net/trustyuri/TrustyUriUtils.java
+++ b/src/main/java/net/trustyuri/TrustyUriUtils.java
@@ -2,8 +2,8 @@ package net.trustyuri;
 
 import java.security.MessageDigest;
 
-import javax.activation.MimetypesFileTypeMap;
-import javax.xml.bind.DatatypeConverter;
+import jakarta.activation.MimetypesFileTypeMap;
+import jakarta.xml.bind.DatatypeConverter;
 
 import net.trustyuri.rdf.RdfHasher;
 


### PR DESCRIPTION
This PR migrates the xml-bind and activation dependencies from javax to jakarta. Javax has been deprecated for several years now and has since been unmaintained (see [Maven](https://mvnrepository.com/artifact/javax.activation/activation)). The reason I'm making this PR is that we want to use the [nanopub-java](https://github.com/Nanopublication/nanopub-java) library in the [ORKG](https://orkg.org/). The problem arises when gathering all dependencies. The ORKG backend is based on the latest spring version, which uses jakarta libraries. The nanopub library depends on the trustyuri library, which in turn depends on javax libraries. However, because of capability resolution, we can only have either jakarta, or javax libraries in our classpath, while the latter is breaking spring libraries. The only way to fix the issue, is to migrate the dependencies of the trustyuri and nanopub libraries from javax to jakarta.