### PR TITLE
Add GH action for testing, add log messages, update deps and minor code refactor

### DIFF
--- a/.github/workflows/maven-test.yml
+++ b/.github/workflows/maven-test.yml
@@ -1,0 +1,29 @@
+name: Maven Test
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        distribution: [ "temurin" ]
+        java: [ "21" , "23", "25" ]
+    name: Testing with Java ${{ matrix.java }} (${{ matrix.distribution }})
+    steps:
+      - name: Checkout
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+
+      - name: Set up JDK
+        uses: actions/setup-java@f2beeb24e141e01a676f977032f5a29d81c9e27e # v5.1.0
+        with:
+          distribution: ${{ matrix.distribution }}
+          java-version: ${{ matrix.java }}
+          cache: 'maven'
+
+      - name: Test with Maven
+        run: ./mvnw -B test

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
-*~
-/.*
+.idea/
 /target
 /classpath.txt
 /scratch

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,0 +1,3 @@
+wrapperVersion=3.3.4
+distributionType=only-script
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.12/apache-maven-3.9.12-bin.zip

--- a/mvnw
+++ b/mvnw
@@ -1,0 +1,295 @@
+#!/bin/sh
+# ----------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# ----------------------------------------------------------------------------
+
+# ----------------------------------------------------------------------------
+# Apache Maven Wrapper startup batch script, version 3.3.4
+#
+# Optional ENV vars
+# -----------------
+#   JAVA_HOME - location of a JDK home dir, required when download maven via java source
+#   MVNW_REPOURL - repo url base for downloading maven distribution
+#   MVNW_USERNAME/MVNW_PASSWORD - user and password for downloading maven
+#   MVNW_VERBOSE - true: enable verbose log; debug: trace the mvnw script; others: silence the output
+# ----------------------------------------------------------------------------
+
+set -euf
+[ "${MVNW_VERBOSE-}" != debug ] || set -x
+
+# OS specific support.
+native_path() { printf %s\\n "$1"; }
+case "$(uname)" in
+CYGWIN* | MINGW*)
+  [ -z "${JAVA_HOME-}" ] || JAVA_HOME="$(cygpath --unix "$JAVA_HOME")"
+  native_path() { cygpath --path --windows "$1"; }
+  ;;
+esac
+
+# set JAVACMD and JAVACCMD
+set_java_home() {
+  # For Cygwin and MinGW, ensure paths are in Unix format before anything is touched
+  if [ -n "${JAVA_HOME-}" ]; then
+    if [ -x "$JAVA_HOME/jre/sh/java" ]; then
+      # IBM's JDK on AIX uses strange locations for the executables
+      JAVACMD="$JAVA_HOME/jre/sh/java"
+      JAVACCMD="$JAVA_HOME/jre/sh/javac"
+    else
+      JAVACMD="$JAVA_HOME/bin/java"
+      JAVACCMD="$JAVA_HOME/bin/javac"
+
+      if [ ! -x "$JAVACMD" ] || [ ! -x "$JAVACCMD" ]; then
+        echo "The JAVA_HOME environment variable is not defined correctly, so mvnw cannot run." >&2
+        echo "JAVA_HOME is set to \"$JAVA_HOME\", but \"\$JAVA_HOME/bin/java\" or \"\$JAVA_HOME/bin/javac\" does not exist." >&2
+        return 1
+      fi
+    fi
+  else
+    JAVACMD="$(
+      'set' +e
+      'unset' -f command 2>/dev/null
+      'command' -v java
+    )" || :
+    JAVACCMD="$(
+      'set' +e
+      'unset' -f command 2>/dev/null
+      'command' -v javac
+    )" || :
+
+    if [ ! -x "${JAVACMD-}" ] || [ ! -x "${JAVACCMD-}" ]; then
+      echo "The java/javac command does not exist in PATH nor is JAVA_HOME set, so mvnw cannot run." >&2
+      return 1
+    fi
+  fi
+}
+
+# hash string like Java String::hashCode
+hash_string() {
+  str="${1:-}" h=0
+  while [ -n "$str" ]; do
+    char="${str%"${str#?}"}"
+    h=$(((h * 31 + $(LC_CTYPE=C printf %d "'$char")) % 4294967296))
+    str="${str#?}"
+  done
+  printf %x\\n $h
+}
+
+verbose() { :; }
+[ "${MVNW_VERBOSE-}" != true ] || verbose() { printf %s\\n "${1-}"; }
+
+die() {
+  printf %s\\n "$1" >&2
+  exit 1
+}
+
+trim() {
+  # MWRAPPER-139:
+  #   Trims trailing and leading whitespace, carriage returns, tabs, and linefeeds.
+  #   Needed for removing poorly interpreted newline sequences when running in more
+  #   exotic environments such as mingw bash on Windows.
+  printf "%s" "${1}" | tr -d '[:space:]'
+}
+
+scriptDir="$(dirname "$0")"
+scriptName="$(basename "$0")"
+
+# parse distributionUrl and optional distributionSha256Sum, requires .mvn/wrapper/maven-wrapper.properties
+while IFS="=" read -r key value; do
+  case "${key-}" in
+  distributionUrl) distributionUrl=$(trim "${value-}") ;;
+  distributionSha256Sum) distributionSha256Sum=$(trim "${value-}") ;;
+  esac
+done <"$scriptDir/.mvn/wrapper/maven-wrapper.properties"
+[ -n "${distributionUrl-}" ] || die "cannot read distributionUrl property in $scriptDir/.mvn/wrapper/maven-wrapper.properties"
+
+case "${distributionUrl##*/}" in
+maven-mvnd-*bin.*)
+  MVN_CMD=mvnd.sh _MVNW_REPO_PATTERN=/maven/mvnd/
+  case "${PROCESSOR_ARCHITECTURE-}${PROCESSOR_ARCHITEW6432-}:$(uname -a)" in
+  *AMD64:CYGWIN* | *AMD64:MINGW*) distributionPlatform=windows-amd64 ;;
+  :Darwin*x86_64) distributionPlatform=darwin-amd64 ;;
+  :Darwin*arm64) distributionPlatform=darwin-aarch64 ;;
+  :Linux*x86_64*) distributionPlatform=linux-amd64 ;;
+  *)
+    echo "Cannot detect native platform for mvnd on $(uname)-$(uname -m), use pure java version" >&2
+    distributionPlatform=linux-amd64
+    ;;
+  esac
+  distributionUrl="${distributionUrl%-bin.*}-$distributionPlatform.zip"
+  ;;
+maven-mvnd-*) MVN_CMD=mvnd.sh _MVNW_REPO_PATTERN=/maven/mvnd/ ;;
+*) MVN_CMD="mvn${scriptName#mvnw}" _MVNW_REPO_PATTERN=/org/apache/maven/ ;;
+esac
+
+# apply MVNW_REPOURL and calculate MAVEN_HOME
+# maven home pattern: ~/.m2/wrapper/dists/{apache-maven-<version>,maven-mvnd-<version>-<platform>}/<hash>
+[ -z "${MVNW_REPOURL-}" ] || distributionUrl="$MVNW_REPOURL$_MVNW_REPO_PATTERN${distributionUrl#*"$_MVNW_REPO_PATTERN"}"
+distributionUrlName="${distributionUrl##*/}"
+distributionUrlNameMain="${distributionUrlName%.*}"
+distributionUrlNameMain="${distributionUrlNameMain%-bin}"
+MAVEN_USER_HOME="${MAVEN_USER_HOME:-${HOME}/.m2}"
+MAVEN_HOME="${MAVEN_USER_HOME}/wrapper/dists/${distributionUrlNameMain-}/$(hash_string "$distributionUrl")"
+
+exec_maven() {
+  unset MVNW_VERBOSE MVNW_USERNAME MVNW_PASSWORD MVNW_REPOURL || :
+  exec "$MAVEN_HOME/bin/$MVN_CMD" "$@" || die "cannot exec $MAVEN_HOME/bin/$MVN_CMD"
+}
+
+if [ -d "$MAVEN_HOME" ]; then
+  verbose "found existing MAVEN_HOME at $MAVEN_HOME"
+  exec_maven "$@"
+fi
+
+case "${distributionUrl-}" in
+*?-bin.zip | *?maven-mvnd-?*-?*.zip) ;;
+*) die "distributionUrl is not valid, must match *-bin.zip or maven-mvnd-*.zip, but found '${distributionUrl-}'" ;;
+esac
+
+# prepare tmp dir
+if TMP_DOWNLOAD_DIR="$(mktemp -d)" && [ -d "$TMP_DOWNLOAD_DIR" ]; then
+  clean() { rm -rf -- "$TMP_DOWNLOAD_DIR"; }
+  trap clean HUP INT TERM EXIT
+else
+  die "cannot create temp dir"
+fi
+
+mkdir -p -- "${MAVEN_HOME%/*}"
+
+# Download and Install Apache Maven
+verbose "Couldn't find MAVEN_HOME, downloading and installing it ..."
+verbose "Downloading from: $distributionUrl"
+verbose "Downloading to: $TMP_DOWNLOAD_DIR/$distributionUrlName"
+
+# select .zip or .tar.gz
+if ! command -v unzip >/dev/null; then
+  distributionUrl="${distributionUrl%.zip}.tar.gz"
+  distributionUrlName="${distributionUrl##*/}"
+fi
+
+# verbose opt
+__MVNW_QUIET_WGET=--quiet __MVNW_QUIET_CURL=--silent __MVNW_QUIET_UNZIP=-q __MVNW_QUIET_TAR=''
+[ "${MVNW_VERBOSE-}" != true ] || __MVNW_QUIET_WGET='' __MVNW_QUIET_CURL='' __MVNW_QUIET_UNZIP='' __MVNW_QUIET_TAR=v
+
+# normalize http auth
+case "${MVNW_PASSWORD:+has-password}" in
+'') MVNW_USERNAME='' MVNW_PASSWORD='' ;;
+has-password) [ -n "${MVNW_USERNAME-}" ] || MVNW_USERNAME='' MVNW_PASSWORD='' ;;
+esac
+
+if [ -z "${MVNW_USERNAME-}" ] && command -v wget >/dev/null; then
+  verbose "Found wget ... using wget"
+  wget ${__MVNW_QUIET_WGET:+"$__MVNW_QUIET_WGET"} "$distributionUrl" -O "$TMP_DOWNLOAD_DIR/$distributionUrlName" || die "wget: Failed to fetch $distributionUrl"
+elif [ -z "${MVNW_USERNAME-}" ] && command -v curl >/dev/null; then
+  verbose "Found curl ... using curl"
+  curl ${__MVNW_QUIET_CURL:+"$__MVNW_QUIET_CURL"} -f -L -o "$TMP_DOWNLOAD_DIR/$distributionUrlName" "$distributionUrl" || die "curl: Failed to fetch $distributionUrl"
+elif set_java_home; then
+  verbose "Falling back to use Java to download"
+  javaSource="$TMP_DOWNLOAD_DIR/Downloader.java"
+  targetZip="$TMP_DOWNLOAD_DIR/$distributionUrlName"
+  cat >"$javaSource" <<-END
+	public class Downloader extends java.net.Authenticator
+	{
+	  protected java.net.PasswordAuthentication getPasswordAuthentication()
+	  {
+	    return new java.net.PasswordAuthentication( System.getenv( "MVNW_USERNAME" ), System.getenv( "MVNW_PASSWORD" ).toCharArray() );
+	  }
+	  public static void main( String[] args ) throws Exception
+	  {
+	    setDefault( new Downloader() );
+	    java.nio.file.Files.copy( java.net.URI.create( args[0] ).toURL().openStream(), java.nio.file.Paths.get( args[1] ).toAbsolutePath().normalize() );
+	  }
+	}
+	END
+  # For Cygwin/MinGW, switch paths to Windows format before running javac and java
+  verbose " - Compiling Downloader.java ..."
+  "$(native_path "$JAVACCMD")" "$(native_path "$javaSource")" || die "Failed to compile Downloader.java"
+  verbose " - Running Downloader.java ..."
+  "$(native_path "$JAVACMD")" -cp "$(native_path "$TMP_DOWNLOAD_DIR")" Downloader "$distributionUrl" "$(native_path "$targetZip")"
+fi
+
+# If specified, validate the SHA-256 sum of the Maven distribution zip file
+if [ -n "${distributionSha256Sum-}" ]; then
+  distributionSha256Result=false
+  if [ "$MVN_CMD" = mvnd.sh ]; then
+    echo "Checksum validation is not supported for maven-mvnd." >&2
+    echo "Please disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties." >&2
+    exit 1
+  elif command -v sha256sum >/dev/null; then
+    if echo "$distributionSha256Sum  $TMP_DOWNLOAD_DIR/$distributionUrlName" | sha256sum -c - >/dev/null 2>&1; then
+      distributionSha256Result=true
+    fi
+  elif command -v shasum >/dev/null; then
+    if echo "$distributionSha256Sum  $TMP_DOWNLOAD_DIR/$distributionUrlName" | shasum -a 256 -c >/dev/null 2>&1; then
+      distributionSha256Result=true
+    fi
+  else
+    echo "Checksum validation was requested but neither 'sha256sum' or 'shasum' are available." >&2
+    echo "Please install either command, or disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties." >&2
+    exit 1
+  fi
+  if [ $distributionSha256Result = false ]; then
+    echo "Error: Failed to validate Maven distribution SHA-256, your Maven distribution might be compromised." >&2
+    echo "If you updated your Maven version, you need to update the specified distributionSha256Sum property." >&2
+    exit 1
+  fi
+fi
+
+# unzip and move
+if command -v unzip >/dev/null; then
+  unzip ${__MVNW_QUIET_UNZIP:+"$__MVNW_QUIET_UNZIP"} "$TMP_DOWNLOAD_DIR/$distributionUrlName" -d "$TMP_DOWNLOAD_DIR" || die "failed to unzip"
+else
+  tar xzf${__MVNW_QUIET_TAR:+"$__MVNW_QUIET_TAR"} "$TMP_DOWNLOAD_DIR/$distributionUrlName" -C "$TMP_DOWNLOAD_DIR" || die "failed to untar"
+fi
+
+# Find the actual extracted directory name (handles snapshots where filename != directory name)
+actualDistributionDir=""
+
+# First try the expected directory name (for regular distributions)
+if [ -d "$TMP_DOWNLOAD_DIR/$distributionUrlNameMain" ]; then
+  if [ -f "$TMP_DOWNLOAD_DIR/$distributionUrlNameMain/bin/$MVN_CMD" ]; then
+    actualDistributionDir="$distributionUrlNameMain"
+  fi
+fi
+
+# If not found, search for any directory with the Maven executable (for snapshots)
+if [ -z "$actualDistributionDir" ]; then
+  # enable globbing to iterate over items
+  set +f
+  for dir in "$TMP_DOWNLOAD_DIR"/*; do
+    if [ -d "$dir" ]; then
+      if [ -f "$dir/bin/$MVN_CMD" ]; then
+        actualDistributionDir="$(basename "$dir")"
+        break
+      fi
+    fi
+  done
+  set -f
+fi
+
+if [ -z "$actualDistributionDir" ]; then
+  verbose "Contents of $TMP_DOWNLOAD_DIR:"
+  verbose "$(ls -la "$TMP_DOWNLOAD_DIR")"
+  die "Could not find Maven distribution directory in extracted archive"
+fi
+
+verbose "Found extracted Maven distribution directory: $actualDistributionDir"
+printf %s\\n "$distributionUrl" >"$TMP_DOWNLOAD_DIR/$actualDistributionDir/mvnw.url"
+mv -- "$TMP_DOWNLOAD_DIR/$actualDistributionDir" "$MAVEN_HOME" || [ -d "$MAVEN_HOME" ] || die "fail to move MAVEN_HOME"
+
+clean || :
+exec_maven "$@"

--- a/mvnw.cmd
+++ b/mvnw.cmd
@@ -1,0 +1,189 @@
+<# : batch portion
+@REM ----------------------------------------------------------------------------
+@REM Licensed to the Apache Software Foundation (ASF) under one
+@REM or more contributor license agreements.  See the NOTICE file
+@REM distributed with this work for additional information
+@REM regarding copyright ownership.  The ASF licenses this file
+@REM to you under the Apache License, Version 2.0 (the
+@REM "License"); you may not use this file except in compliance
+@REM with the License.  You may obtain a copy of the License at
+@REM
+@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM
+@REM Unless required by applicable law or agreed to in writing,
+@REM software distributed under the License is distributed on an
+@REM "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+@REM KIND, either express or implied.  See the License for the
+@REM specific language governing permissions and limitations
+@REM under the License.
+@REM ----------------------------------------------------------------------------
+
+@REM ----------------------------------------------------------------------------
+@REM Apache Maven Wrapper startup batch script, version 3.3.4
+@REM
+@REM Optional ENV vars
+@REM   MVNW_REPOURL - repo url base for downloading maven distribution
+@REM   MVNW_USERNAME/MVNW_PASSWORD - user and password for downloading maven
+@REM   MVNW_VERBOSE - true: enable verbose log; others: silence the output
+@REM ----------------------------------------------------------------------------
+
+@IF "%__MVNW_ARG0_NAME__%"=="" (SET __MVNW_ARG0_NAME__=%~nx0)
+@SET __MVNW_CMD__=
+@SET __MVNW_ERROR__=
+@SET __MVNW_PSMODULEP_SAVE=%PSModulePath%
+@SET PSModulePath=
+@FOR /F "usebackq tokens=1* delims==" %%A IN (`powershell -noprofile "& {$scriptDir='%~dp0'; $script='%__MVNW_ARG0_NAME__%'; icm -ScriptBlock ([Scriptblock]::Create((Get-Content -Raw '%~f0'))) -NoNewScope}"`) DO @(
+  IF "%%A"=="MVN_CMD" (set __MVNW_CMD__=%%B) ELSE IF "%%B"=="" (echo %%A) ELSE (echo %%A=%%B)
+)
+@SET PSModulePath=%__MVNW_PSMODULEP_SAVE%
+@SET __MVNW_PSMODULEP_SAVE=
+@SET __MVNW_ARG0_NAME__=
+@SET MVNW_USERNAME=
+@SET MVNW_PASSWORD=
+@IF NOT "%__MVNW_CMD__%"=="" ("%__MVNW_CMD__%" %*)
+@echo Cannot start maven from wrapper >&2 && exit /b 1
+@GOTO :EOF
+: end batch / begin powershell #>
+
+$ErrorActionPreference = "Stop"
+if ($env:MVNW_VERBOSE -eq "true") {
+  $VerbosePreference = "Continue"
+}
+
+# calculate distributionUrl, requires .mvn/wrapper/maven-wrapper.properties
+$distributionUrl = (Get-Content -Raw "$scriptDir/.mvn/wrapper/maven-wrapper.properties" | ConvertFrom-StringData).distributionUrl
+if (!$distributionUrl) {
+  Write-Error "cannot read distributionUrl property in $scriptDir/.mvn/wrapper/maven-wrapper.properties"
+}
+
+switch -wildcard -casesensitive ( $($distributionUrl -replace '^.*/','') ) {
+  "maven-mvnd-*" {
+    $USE_MVND = $true
+    $distributionUrl = $distributionUrl -replace '-bin\.[^.]*$',"-windows-amd64.zip"
+    $MVN_CMD = "mvnd.cmd"
+    break
+  }
+  default {
+    $USE_MVND = $false
+    $MVN_CMD = $script -replace '^mvnw','mvn'
+    break
+  }
+}
+
+# apply MVNW_REPOURL and calculate MAVEN_HOME
+# maven home pattern: ~/.m2/wrapper/dists/{apache-maven-<version>,maven-mvnd-<version>-<platform>}/<hash>
+if ($env:MVNW_REPOURL) {
+  $MVNW_REPO_PATTERN = if ($USE_MVND -eq $False) { "/org/apache/maven/" } else { "/maven/mvnd/" }
+  $distributionUrl = "$env:MVNW_REPOURL$MVNW_REPO_PATTERN$($distributionUrl -replace "^.*$MVNW_REPO_PATTERN",'')"
+}
+$distributionUrlName = $distributionUrl -replace '^.*/',''
+$distributionUrlNameMain = $distributionUrlName -replace '\.[^.]*$','' -replace '-bin$',''
+
+$MAVEN_M2_PATH = "$HOME/.m2"
+if ($env:MAVEN_USER_HOME) {
+  $MAVEN_M2_PATH = "$env:MAVEN_USER_HOME"
+}
+
+if (-not (Test-Path -Path $MAVEN_M2_PATH)) {
+    New-Item -Path $MAVEN_M2_PATH -ItemType Directory | Out-Null
+}
+
+$MAVEN_WRAPPER_DISTS = $null
+if ((Get-Item $MAVEN_M2_PATH).Target[0] -eq $null) {
+  $MAVEN_WRAPPER_DISTS = "$MAVEN_M2_PATH/wrapper/dists"
+} else {
+  $MAVEN_WRAPPER_DISTS = (Get-Item $MAVEN_M2_PATH).Target[0] + "/wrapper/dists"
+}
+
+$MAVEN_HOME_PARENT = "$MAVEN_WRAPPER_DISTS/$distributionUrlNameMain"
+$MAVEN_HOME_NAME = ([System.Security.Cryptography.SHA256]::Create().ComputeHash([byte[]][char[]]$distributionUrl) | ForEach-Object {$_.ToString("x2")}) -join ''
+$MAVEN_HOME = "$MAVEN_HOME_PARENT/$MAVEN_HOME_NAME"
+
+if (Test-Path -Path "$MAVEN_HOME" -PathType Container) {
+  Write-Verbose "found existing MAVEN_HOME at $MAVEN_HOME"
+  Write-Output "MVN_CMD=$MAVEN_HOME/bin/$MVN_CMD"
+  exit $?
+}
+
+if (! $distributionUrlNameMain -or ($distributionUrlName -eq $distributionUrlNameMain)) {
+  Write-Error "distributionUrl is not valid, must end with *-bin.zip, but found $distributionUrl"
+}
+
+# prepare tmp dir
+$TMP_DOWNLOAD_DIR_HOLDER = New-TemporaryFile
+$TMP_DOWNLOAD_DIR = New-Item -Itemtype Directory -Path "$TMP_DOWNLOAD_DIR_HOLDER.dir"
+$TMP_DOWNLOAD_DIR_HOLDER.Delete() | Out-Null
+trap {
+  if ($TMP_DOWNLOAD_DIR.Exists) {
+    try { Remove-Item $TMP_DOWNLOAD_DIR -Recurse -Force | Out-Null }
+    catch { Write-Warning "Cannot remove $TMP_DOWNLOAD_DIR" }
+  }
+}
+
+New-Item -Itemtype Directory -Path "$MAVEN_HOME_PARENT" -Force | Out-Null
+
+# Download and Install Apache Maven
+Write-Verbose "Couldn't find MAVEN_HOME, downloading and installing it ..."
+Write-Verbose "Downloading from: $distributionUrl"
+Write-Verbose "Downloading to: $TMP_DOWNLOAD_DIR/$distributionUrlName"
+
+$webclient = New-Object System.Net.WebClient
+if ($env:MVNW_USERNAME -and $env:MVNW_PASSWORD) {
+  $webclient.Credentials = New-Object System.Net.NetworkCredential($env:MVNW_USERNAME, $env:MVNW_PASSWORD)
+}
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+$webclient.DownloadFile($distributionUrl, "$TMP_DOWNLOAD_DIR/$distributionUrlName") | Out-Null
+
+# If specified, validate the SHA-256 sum of the Maven distribution zip file
+$distributionSha256Sum = (Get-Content -Raw "$scriptDir/.mvn/wrapper/maven-wrapper.properties" | ConvertFrom-StringData).distributionSha256Sum
+if ($distributionSha256Sum) {
+  if ($USE_MVND) {
+    Write-Error "Checksum validation is not supported for maven-mvnd. `nPlease disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties."
+  }
+  Import-Module $PSHOME\Modules\Microsoft.PowerShell.Utility -Function Get-FileHash
+  if ((Get-FileHash "$TMP_DOWNLOAD_DIR/$distributionUrlName" -Algorithm SHA256).Hash.ToLower() -ne $distributionSha256Sum) {
+    Write-Error "Error: Failed to validate Maven distribution SHA-256, your Maven distribution might be compromised. If you updated your Maven version, you need to update the specified distributionSha256Sum property."
+  }
+}
+
+# unzip and move
+Expand-Archive "$TMP_DOWNLOAD_DIR/$distributionUrlName" -DestinationPath "$TMP_DOWNLOAD_DIR" | Out-Null
+
+# Find the actual extracted directory name (handles snapshots where filename != directory name)
+$actualDistributionDir = ""
+
+# First try the expected directory name (for regular distributions)
+$expectedPath = Join-Path "$TMP_DOWNLOAD_DIR" "$distributionUrlNameMain"
+$expectedMvnPath = Join-Path "$expectedPath" "bin/$MVN_CMD"
+if ((Test-Path -Path $expectedPath -PathType Container) -and (Test-Path -Path $expectedMvnPath -PathType Leaf)) {
+  $actualDistributionDir = $distributionUrlNameMain
+}
+
+# If not found, search for any directory with the Maven executable (for snapshots)
+if (!$actualDistributionDir) {
+  Get-ChildItem -Path "$TMP_DOWNLOAD_DIR" -Directory | ForEach-Object {
+    $testPath = Join-Path $_.FullName "bin/$MVN_CMD"
+    if (Test-Path -Path $testPath -PathType Leaf) {
+      $actualDistributionDir = $_.Name
+    }
+  }
+}
+
+if (!$actualDistributionDir) {
+  Write-Error "Could not find Maven distribution directory in extracted archive"
+}
+
+Write-Verbose "Found extracted Maven distribution directory: $actualDistributionDir"
+Rename-Item -Path "$TMP_DOWNLOAD_DIR/$actualDistributionDir" -NewName $MAVEN_HOME_NAME | Out-Null
+try {
+  Move-Item -Path "$TMP_DOWNLOAD_DIR/$MAVEN_HOME_NAME" -Destination $MAVEN_HOME_PARENT | Out-Null
+} catch {
+  if (! (Test-Path -Path "$MAVEN_HOME" -PathType Container)) {
+    Write-Error "fail to move MAVEN_HOME"
+  }
+} finally {
+  try { Remove-Item $TMP_DOWNLOAD_DIR -Recurse -Force | Out-Null }
+  catch { Write-Warning "Cannot remove $TMP_DOWNLOAD_DIR" }
+}
+
+Write-Output "MVN_CMD=$MAVEN_HOME/bin/$MVN_CMD"

--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
-      <version>3.18.0</version>
+      <version>3.20.0</version>
     </dependency>
     <dependency>
       <groupId>com.google.code.externalsortinginjava</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>2.20.0</version>
+      <version>2.21.0</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>net.trustyuri</groupId>
   <artifactId>trustyuri</artifactId>
@@ -49,13 +50,13 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-      <version>2.1.0-alpha1</version>
+      <version>2.0.17</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-simple</artifactId>
-      <version>2.1.0-alpha1</version>
-      <optional>true</optional>
+      <version>2.0.17</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.eclipse.rdf4j</groupId>
@@ -168,12 +169,12 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-release-plugin</artifactId>
         <version>3.1.1</version>
-          <configuration>
-            <autoVersionSubmodules>true</autoVersionSubmodules>
-            <useReleaseProfile>false</useReleaseProfile>
-            <releaseProfiles>release</releaseProfiles>
-            <goals>deploy</goals>
-          </configuration>
+        <configuration>
+          <autoVersionSubmodules>true</autoVersionSubmodules>
+          <useReleaseProfile>false</useReleaseProfile>
+          <releaseProfiles>release</releaseProfiles>
+          <goals>deploy</goals>
+        </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -200,53 +201,53 @@
   <profiles>
     <profile>
       <id>release</id>
-  <properties>
-    <maven.compiler.source>17</maven.compiler.source>
-    <maven.compiler.target>17</maven.compiler.target>
-  </properties>
+      <properties>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+      </properties>
       <build>
         <plugins>
- 
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-source-plugin</artifactId>
-        <version>3.3.1</version>
-        <executions>
-          <execution>
-            <id>attach-sources</id>
-            <goals>
-              <goal>jar-no-fork</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-javadoc-plugin</artifactId>
-        <version>3.8.0</version>
-        <executions>
-          <execution>
-            <id>attach-javadocs</id>
-            <goals>
-              <goal>jar</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-gpg-plugin</artifactId>
-        <version>3.2.5</version>
-        <executions>
-          <execution>
-            <id>sign-artifacts</id>
-            <phase>verify</phase>
-            <goals>
-              <goal>sign</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
+
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-source-plugin</artifactId>
+            <version>3.3.1</version>
+            <executions>
+              <execution>
+                <id>attach-sources</id>
+                <goals>
+                  <goal>jar-no-fork</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <version>3.8.0</version>
+            <executions>
+              <execution>
+                <id>attach-javadocs</id>
+                <goals>
+                  <goal>jar</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-gpg-plugin</artifactId>
+            <version>3.2.5</version>
+            <executions>
+              <execution>
+                <id>sign-artifacts</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>sign</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
         </plugins>
       </build>
     </profile>

--- a/src/main/java/net/trustyuri/CheckFile.java
+++ b/src/main/java/net/trustyuri/CheckFile.java
@@ -1,5 +1,8 @@
 package net.trustyuri;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
@@ -12,73 +15,75 @@ import java.net.URL;
  */
 public class CheckFile {
 
-	/**
-	 * Reads and checks the content of one or several URLs (in the form of trusty URIs) or local
-	 * files (in the form of trusty file names).
-	 *
-	 * @param args a list of URLs or file names
-	 */
-	public static void main(String[] args) throws IOException, TrustyUriException {
-		for (String arg : args) {
-			check(arg);
-		}
-	}
+    private static final Logger logger = LoggerFactory.getLogger(CheckFile.class);
 
-	/**
-	 * Check the content of a trusty URI (fetched from the web) or a trusty file (read from the
-	 * file system).
-	 *
-	 * @param fileOrUrl the file name or URL
-	 */
-	public static void check(String fileOrUrl) throws IOException, TrustyUriException {
-		CheckFile c;
-		try {
-			URL url = new URL(fileOrUrl);
-			c = new CheckFile(url);
-		} catch (MalformedURLException ex) {
-			c = new CheckFile(new File(fileOrUrl));
-		}
+    /**
+     * Reads and checks the content of one or several URLs (in the form of trusty URIs) or local
+     * files (in the form of trusty file names).
+     *
+     * @param args a list of URLs or file names
+     */
+    public static void main(String[] args) throws IOException, TrustyUriException {
+        for (String arg : args) {
+            check(arg);
+        }
+    }
 
-		boolean valid = c.check();
-		if (valid) {
-			System.out.println("Correct hash: " + c.r.getArtifactCode());
-			//System.out.println("ni URI: " + TrustyUriUtils.getNiUri(fileName));
-		} else {
-			System.out.println("*** INCORRECT HASH ***");
-		}
-	}
+    /**
+     * Check the content of a trusty URI (fetched from the web) or a trusty file (read from the
+     * file system).
+     *
+     * @param fileOrUrl the file name or URL
+     */
+    public static void check(String fileOrUrl) throws IOException, TrustyUriException {
+        CheckFile c;
+        try {
+            URL url = new URL(fileOrUrl);
+            c = new CheckFile(url);
+        } catch (MalformedURLException ex) {
+            c = new CheckFile(new File(fileOrUrl));
+        }
 
-	private TrustyUriResource r;
+        boolean valid = c.check();
+        if (valid) {
+            logger.info("Correct hash: {}", c.r.getArtifactCode());
+            //System.out.println("ni URI: " + TrustyUriUtils.getNiUri(fileName));
+        } else {
+            logger.error("*** INCORRECT HASH ***");
+        }
+    }
 
-	/**
-	 * Creates a new object to check the content to be fetch from a URL.
-	 *
-	 * @param url the URL
-	 */
-	public CheckFile(URL url) throws IOException {
-		r = new TrustyUriResource(url);
-	}
+    private TrustyUriResource r;
 
-	/**
-	 * Creates a new object to check the content to be read from a local file.
-	 *
-	 * @param file
-	 */
-	public CheckFile(File file) throws IOException {
-		r = new TrustyUriResource(file);
-	}
+    /**
+     * Creates a new object to check the content to be fetch from a URL.
+     *
+     * @param url the URL
+     */
+    public CheckFile(URL url) throws IOException {
+        r = new TrustyUriResource(url);
+    }
 
-	/**
-	 * Checks whether the content matches the hash of the trusty URI.
-	 *
-	 * @return true if the content matches the hash
-	 */
-	public boolean check() throws IOException, TrustyUriException {
-		TrustyUriModule module = ModuleDirectory.getModule(r.getModuleId());
-		if (module == null) {
-			throw new TrustyUriException("ERROR: Not a trusty URI or unknown module");
-		}
-		return module.hasCorrectHash(r);
-	}
+    /**
+     * Creates a new object to check the content to be read from a local file.
+     *
+     * @param file
+     */
+    public CheckFile(File file) throws IOException {
+        r = new TrustyUriResource(file);
+    }
+
+    /**
+     * Checks whether the content matches the hash of the trusty URI.
+     *
+     * @return true if the content matches the hash
+     */
+    public boolean check() throws IOException, TrustyUriException {
+        TrustyUriModule module = ModuleDirectory.getModule(r.getModuleId());
+        if (module == null) {
+            throw new TrustyUriException("ERROR: Not a trusty URI or unknown module");
+        }
+        return module.hasCorrectHash(r);
+    }
 
 }

--- a/src/main/java/net/trustyuri/RunBatch.java
+++ b/src/main/java/net/trustyuri/RunBatch.java
@@ -1,69 +1,74 @@
 package net.trustyuri;
 
+import org.eclipse.rdf4j.common.exception.RDF4JException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-
-import org.eclipse.rdf4j.common.exception.RDF4JException;
 
 public class RunBatch {
 
-	private RunBatch() {}  // no instances allowed
+    private static final Logger logger = LoggerFactory.getLogger(RunBatch.class);
 
-	public static void main(String[] args) throws IOException, RDF4JException, TrustyUriException {
-		String batchFile = args[0];
+    private RunBatch() {
+    }  // no instances allowed
 
-		BufferedReader reader = new BufferedReader(new FileReader(batchFile));
-		int startFrom = 0;
+    public static void main(String[] args) throws IOException, RDF4JException, TrustyUriException {
+        String batchFile = args[0];
 
-		File runningFile = new File(batchFile + ".running");
-		if (runningFile.exists()) {
-			startFrom = new Integer(readFile(runningFile)) + 1;
-			System.out.println("===");
-			System.out.println("RESUMING at line " + startFrom);
-			System.out.println("===");
-		} else {
-			writeFile(runningFile, startFrom + "");
-		}
+        BufferedReader reader = new BufferedReader(new FileReader(batchFile));
+        int startFrom = 0;
 
-		String line;
-		int lineNumber = -1;
-		while ((line = reader.readLine()) != null) {
-			line = line.trim();
-			if (line.isEmpty() || line.charAt(0) == '#') continue;
-			lineNumber = lineNumber + 1;
-			if (startFrom > lineNumber) continue;
-			writeFile(runningFile, lineNumber + "");
-			System.out.println("COMMAND: " + line);
-			String[] cmd = line.split("\\s+");
-			long ns = System.nanoTime();
-			try {
-				Run.run(cmd);
-			} catch (Exception ex) {
-				ex.printStackTrace();
-			} catch (OutOfMemoryError err) {
-				err.printStackTrace();
-				System.exit(99);
-			}
-			long t = System.nanoTime() - ns;
-			System.out.println("Time in seconds: " + t/1000000000.0);
-			System.out.println("---");
-		}
-		reader.close();
-		runningFile.delete();
-	}
+        File runningFile = new File(batchFile + ".running");
+        if (runningFile.exists()) {
+            startFrom = Integer.parseInt(readFile(runningFile)) + 1;
+            System.out.println("===");
+            System.out.println("RESUMING at line " + startFrom);
+            System.out.println("===");
+        } else {
+            writeFile(runningFile, startFrom + "");
+        }
 
-	static String readFile(File file) throws IOException {
-		byte[] encoded = Files.readAllBytes(file.toPath());
-		return Charset.forName("UTF-8").decode(ByteBuffer.wrap(encoded)).toString();
-	}
+        String line;
+        int lineNumber = -1;
+        while ((line = reader.readLine()) != null) {
+            line = line.trim();
+            if (line.isEmpty() || line.charAt(0) == '#') continue;
+            lineNumber = lineNumber + 1;
+            if (startFrom > lineNumber) continue;
+            writeFile(runningFile, lineNumber + "");
+            System.out.println("COMMAND: " + line);
+            String[] cmd = line.split("\\s+");
+            long ns = System.nanoTime();
+            try {
+                Run.run(cmd);
+            } catch (Exception ex) {
+                logger.error(ex.getMessage(), ex);
+            } catch (OutOfMemoryError err) {
+                logger.error(err.getMessage(), err);
+                System.exit(99);
+            }
+            long t = System.nanoTime() - ns;
+            System.out.println("Time in seconds: " + t / 1000000000.0);
+            System.out.println("---");
+        }
+        reader.close();
+        runningFile.delete();
+    }
 
-	static void writeFile(File file, String content) throws IOException {
-		Files.write(file.toPath(), content.getBytes());
-	}
+    static String readFile(File file) throws IOException {
+        byte[] encoded = Files.readAllBytes(file.toPath());
+        return StandardCharsets.UTF_8.decode(ByteBuffer.wrap(encoded)).toString();
+    }
+
+    static void writeFile(File file, String content) throws IOException {
+        Files.write(file.toPath(), content.getBytes());
+    }
 
 }

--- a/src/main/java/net/trustyuri/rdf/CheckLargeRdf.java
+++ b/src/main/java/net/trustyuri/rdf/CheckLargeRdf.java
@@ -1,107 +1,105 @@
 package net.trustyuri.rdf;
 
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.FileReader;
-import java.io.IOException;
-import java.nio.charset.Charset;
-import java.security.MessageDigest;
-import java.util.Comparator;
-import java.util.List;
-
+import com.google.code.externalsorting.ExternalSort;
+import net.trustyuri.TrustyUriException;
+import net.trustyuri.TrustyUriResource;
 import org.eclipse.rdf4j.common.exception.RDF4JException;
 import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.RDFHandlerException;
 import org.eclipse.rdf4j.rio.RDFParser;
 import org.eclipse.rdf4j.rio.helpers.AbstractRDFHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-import com.google.code.externalsorting.ExternalSort;
-
-import net.trustyuri.TrustyUriException;
-import net.trustyuri.TrustyUriResource;
+import java.io.*;
+import java.nio.charset.Charset;
+import java.security.MessageDigest;
+import java.util.Comparator;
+import java.util.List;
 
 public class CheckLargeRdf {
 
-	public static void main(String[] args) throws IOException, TrustyUriException {
-		File file = new File(args[0]);
-		CheckLargeRdf t = new CheckLargeRdf(file);
-		boolean valid = t.check();
-		if (valid) {
-			System.out.println("Correct hash: " + t.ac);
-		} else {
-			System.out.println("*** INCORRECT HASH ***");
-		}
-	}
+    private static final Logger logger = LoggerFactory.getLogger(CheckLargeRdf.class);
 
-	private File file;
-	private MessageDigest md;
-	private String ac;
+    public static void main(String[] args) throws IOException, TrustyUriException {
+        File file = new File(args[0]);
+        CheckLargeRdf t = new CheckLargeRdf(file);
+        boolean valid = t.check();
+        if (valid) {
+            logger.info("Correct hash: {}", t.ac);
+        } else {
+            logger.error("*** INCORRECT HASH ***");
+        }
+    }
 
-	public CheckLargeRdf(File file) {
-		this.file = file;
-	}
+    private File file;
+    private MessageDigest md;
+    private String ac;
 
-	public boolean check() throws IOException, TrustyUriException {
-		TrustyUriResource r = new TrustyUriResource(file);
-		File dir = file.getParentFile();
-		String fileName = file.getName();
-		md = RdfHasher.getDigest();
-		RDFFormat format = r.getFormat(RDFFormat.TURTLE);
+    public CheckLargeRdf(File file) {
+        this.file = file;
+    }
 
-		RDFParser p = RdfUtils.getParser(format);
-		File sortInFile = new File(dir, fileName + ".temp.sort-in");
-		final FileOutputStream preOut = new FileOutputStream(sortInFile);
-		p.setRDFHandler(new RdfPreprocessor(new AbstractRDFHandler() {
+    public boolean check() throws IOException, TrustyUriException {
+        TrustyUriResource r = new TrustyUriResource(file);
+        File dir = file.getParentFile();
+        String fileName = file.getName();
+        md = RdfHasher.getDigest();
+        RDFFormat format = r.getFormat(RDFFormat.TURTLE);
 
-			@Override
-			public void handleStatement(Statement st) throws RDFHandlerException {
-				String s = SerStatementComparator.toString(st) + "\n";
-				try {
-					preOut.write(s.getBytes(Charset.forName("UTF-8")));
-				} catch (IOException ex) {
-					ex.printStackTrace();
-				}
-			}
+        RDFParser p = RdfUtils.getParser(format);
+        File sortInFile = new File(dir, fileName + ".temp.sort-in");
+        final FileOutputStream preOut = new FileOutputStream(sortInFile);
+        p.setRDFHandler(new RdfPreprocessor(new AbstractRDFHandler() {
 
-		}, r.getArtifactCode()));
-		BufferedReader reader = new BufferedReader(r.getInputStreamReader(), 64*1024);
-		try {
-			p.parse(reader, "");
-		} catch (RDF4JException ex) {
-			throw new TrustyUriException(ex);
-		} finally {
-			reader.close();
-			preOut.close();
-		}
+            @Override
+            public void handleStatement(Statement st) throws RDFHandlerException {
+                String s = SerStatementComparator.toString(st) + "\n";
+                try {
+                    preOut.write(s.getBytes(Charset.forName("UTF-8")));
+                } catch (IOException ex) {
+                    ex.printStackTrace();
+                }
+            }
 
-		File sortOutFile = new File(dir, fileName + ".temp.sort-out");
-		File sortTempDir = new File(dir, fileName + ".temp");
-		sortTempDir.mkdir();
-		Comparator<String> cmp = new SerStatementComparator();
-		Charset cs = Charset.defaultCharset();
-		System.gc();
-		List<File> tempFiles = ExternalSort.sortInBatch(sortInFile, cmp, 1024, cs, sortTempDir, false);
-		ExternalSort.mergeSortedFiles(tempFiles, sortOutFile, cmp, cs);
-		sortInFile.delete();
-		sortTempDir.delete();
+        }, r.getArtifactCode()));
+        BufferedReader reader = new BufferedReader(r.getInputStreamReader(), 64 * 1024);
+        try {
+            p.parse(reader, "");
+        } catch (RDF4JException ex) {
+            throw new TrustyUriException(ex);
+        } finally {
+            reader.close();
+            preOut.close();
+        }
 
-		BufferedReader br = new BufferedReader(new FileReader(sortOutFile));
-		String line;
-		Statement previous = null;
-		while ((line = br.readLine()) != null) {
-			Statement st = SerStatementComparator.fromString(line);
-			if (!st.equals(previous)) {
-				RdfHasher.digest(st, md);
-			}
-			previous = st;
-		}
-		br.close();
-		sortOutFile.delete();
+        File sortOutFile = new File(dir, fileName + ".temp.sort-out");
+        File sortTempDir = new File(dir, fileName + ".temp");
+        sortTempDir.mkdir();
+        Comparator<String> cmp = new SerStatementComparator();
+        Charset cs = Charset.defaultCharset();
+        System.gc();
+        List<File> tempFiles = ExternalSort.sortInBatch(sortInFile, cmp, 1024, cs, sortTempDir, false);
+        ExternalSort.mergeSortedFiles(tempFiles, sortOutFile, cmp, cs);
+        sortInFile.delete();
+        sortTempDir.delete();
 
-		ac = RdfHasher.getArtifactCode(md);
-		return ac.equals(r.getArtifactCode());
-	}
+        BufferedReader br = new BufferedReader(new FileReader(sortOutFile));
+        String line;
+        Statement previous = null;
+        while ((line = br.readLine()) != null) {
+            Statement st = SerStatementComparator.fromString(line);
+            if (!st.equals(previous)) {
+                RdfHasher.digest(st, md);
+            }
+            previous = st;
+        }
+        br.close();
+        sortOutFile.delete();
+
+        ac = RdfHasher.getArtifactCode(md);
+        return ac.equals(r.getArtifactCode());
+    }
 
 }

--- a/src/main/java/net/trustyuri/rdf/CheckRdfGraph.java
+++ b/src/main/java/net/trustyuri/rdf/CheckRdfGraph.java
@@ -1,5 +1,14 @@
 package net.trustyuri.rdf;
 
+import net.trustyuri.TrustyUriException;
+import net.trustyuri.TrustyUriResource;
+import net.trustyuri.TrustyUriUtils;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
@@ -7,75 +16,69 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.eclipse.rdf4j.model.IRI;
-import org.eclipse.rdf4j.model.Statement;
-import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
-
-import net.trustyuri.TrustyUriException;
-import net.trustyuri.TrustyUriResource;
-import net.trustyuri.TrustyUriUtils;
-
 public class CheckRdfGraph {
 
-	public static void main(String[] args) throws IOException, TrustyUriException {
-		if (args.length < 2) {
-			throw new RuntimeException("Not enough arguments: <file> <graph-uri1> (<graph-uri2> ...)");
-		}
-		String fileName = args[0];
-		CheckRdfGraph c;
-		try {
-			URL url = new URL(fileName);
-			c = new CheckRdfGraph(url);
-		} catch (MalformedURLException ex) {
-			c = new CheckRdfGraph(new File(fileName));
-		}
-		for (int i = 1 ; i < args.length ; i++) {
-			IRI graphUri = SimpleValueFactory.getInstance().createIRI(args[i]);
-			boolean valid = c.check(graphUri);
-			if (valid) {
-				System.out.println("Correct hash: " + getArtifactCode(graphUri));
-			} else {
-				System.out.println("*** INCORRECT HASH ***");
-			}
-		}
-	}
+    private static final Logger logger = LoggerFactory.getLogger(CheckRdfGraph.class);
 
-	private TrustyUriResource r;
-	private RdfFileContent content;
+    public static void main(String[] args) throws IOException, TrustyUriException {
+        if (args.length < 2) {
+            throw new RuntimeException("Not enough arguments: <file> <graph-uri1> (<graph-uri2> ...)");
+        }
+        String fileName = args[0];
+        CheckRdfGraph c;
+        try {
+            URL url = new URL(fileName);
+            c = new CheckRdfGraph(url);
+        } catch (MalformedURLException ex) {
+            c = new CheckRdfGraph(new File(fileName));
+        }
+        for (int i = 1; i < args.length; i++) {
+            IRI graphUri = SimpleValueFactory.getInstance().createIRI(args[i]);
+            boolean valid = c.check(graphUri);
+            if (valid) {
+                logger.info("Correct hash: {}", getArtifactCode(graphUri));
+            } else {
+                logger.error("*** INCORRECT HASH ***");
+            }
+        }
+    }
 
-	public CheckRdfGraph(URL url) throws IOException, TrustyUriException {
-		r = new TrustyUriResource(url);
-		init();
-	}
+    private TrustyUriResource r;
+    private RdfFileContent content;
 
-	public CheckRdfGraph(File file) throws IOException, TrustyUriException {
-		r = new TrustyUriResource(file);
-		init();
-	}
+    public CheckRdfGraph(URL url) throws IOException, TrustyUriException {
+        r = new TrustyUriResource(url);
+        init();
+    }
 
-	private void init() throws IOException, TrustyUriException {
-		content = RdfUtils.load(r);
-	}
+    public CheckRdfGraph(File file) throws IOException, TrustyUriException {
+        r = new TrustyUriResource(file);
+        init();
+    }
 
-	public boolean check(IRI graphUri) throws TrustyUriException {
-		String artifactCode = getArtifactCode(graphUri);
-		if (artifactCode == null) {
-			throw new TrustyUriException("Not a trusty URI: " + graphUri);
-		}
-		if (!TrustyUriUtils.getModuleId(artifactCode).equals(RdfGraphModule.MODULE_ID)) {
-			throw new TrustyUriException("Not a trusty URI of type " + RdfGraphModule.MODULE_ID + ": " + graphUri);
-		}
-		List<Statement> graph = new ArrayList<Statement>();
-		for (Statement st : content.getStatements()) {
-			if (graphUri.equals(st.getContext())) graph.add(st);
-		}
-		graph = RdfPreprocessor.run(graph, artifactCode);
-		String ac = RdfHasher.makeGraphArtifactCode(graph);
-		return artifactCode.equals(ac);
-	}
+    private void init() throws IOException, TrustyUriException {
+        content = RdfUtils.load(r);
+    }
 
-	private static String getArtifactCode(IRI graphUri) {
-		return TrustyUriUtils.getArtifactCode(graphUri.stringValue());
-	}
+    public boolean check(IRI graphUri) throws TrustyUriException {
+        String artifactCode = getArtifactCode(graphUri);
+        if (artifactCode == null) {
+            throw new TrustyUriException("Not a trusty URI: " + graphUri);
+        }
+        if (!TrustyUriUtils.getModuleId(artifactCode).equals(RdfGraphModule.MODULE_ID)) {
+            throw new TrustyUriException("Not a trusty URI of type " + RdfGraphModule.MODULE_ID + ": " + graphUri);
+        }
+        List<Statement> graph = new ArrayList<Statement>();
+        for (Statement st : content.getStatements()) {
+            if (graphUri.equals(st.getContext())) graph.add(st);
+        }
+        graph = RdfPreprocessor.run(graph, artifactCode);
+        String ac = RdfHasher.makeGraphArtifactCode(graph);
+        return artifactCode.equals(ac);
+    }
+
+    private static String getArtifactCode(IRI graphUri) {
+        return TrustyUriUtils.getArtifactCode(graphUri.stringValue());
+    }
 
 }

--- a/src/main/java/net/trustyuri/rdf/CheckSortedRdf.java
+++ b/src/main/java/net/trustyuri/rdf/CheckSortedRdf.java
@@ -1,88 +1,90 @@
 package net.trustyuri.rdf;
 
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.IOException;
-import java.security.MessageDigest;
-
+import net.trustyuri.TrustyUriException;
+import net.trustyuri.TrustyUriResource;
 import org.eclipse.rdf4j.common.exception.RDF4JException;
 import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.RDFHandlerException;
 import org.eclipse.rdf4j.rio.RDFParser;
 import org.eclipse.rdf4j.rio.helpers.AbstractRDFHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-import net.trustyuri.TrustyUriException;
-import net.trustyuri.TrustyUriResource;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.security.MessageDigest;
 
 public class CheckSortedRdf {
 
-	public static void main(String[] args) throws IOException, TrustyUriException {
-		File file = new File(args[0]);
-		CheckSortedRdf ch = new CheckSortedRdf(file);
-		boolean isCorrect = ch.check();
-		if (isCorrect) {
-			System.out.println("Correct hash: " + ch.getArtifactCode());
-		} else {
-			System.out.println("*** INCORRECT HASH ***");
-		}
-	}
+    private static final Logger logger = LoggerFactory.getLogger(CheckSortedRdf.class);
 
-	private File file;
-	private MessageDigest md;
-	private Statement previous;
-	private TrustyUriResource r;
+    public static void main(String[] args) throws IOException, TrustyUriException {
+        File file = new File(args[0]);
+        CheckSortedRdf ch = new CheckSortedRdf(file);
+        boolean isCorrect = ch.check();
+        if (isCorrect) {
+            logger.info("Correct hash: {}", ch.getArtifactCode());
+        } else {
+            logger.error("*** INCORRECT HASH ***");
+        }
+    }
 
-	public CheckSortedRdf(File file) {
-		this.file = file;
-	}
+    private File file;
+    private MessageDigest md;
+    private Statement previous;
+    private TrustyUriResource r;
 
-	public boolean check() throws IOException, TrustyUriException {
-		md = RdfHasher.getDigest();
-		r = new TrustyUriResource(file);
-		if (r.getArtifactCode() == null) {
-			System.out.println("ERROR: Not a trusty URI or unknown module");
-			System.exit(1);
-		}
-		String moduleId = r.getModuleId();
-		if (!moduleId.equals(RdfModule.MODULE_ID)) {
-			System.out.println("ERROR: Unsupported module: " + moduleId +
-					" (this function only supports " + RdfModule.MODULE_ID + ")");
-			System.exit(1);
-		}
-		RDFFormat format = r.getFormat(RDFFormat.TURTLE);
+    public CheckSortedRdf(File file) {
+        this.file = file;
+    }
 
-		RDFParser p = RdfUtils.getParser(format);
-		previous = null;
-		p.setRDFHandler(new RdfPreprocessor(new AbstractRDFHandler() {
+    public boolean check() throws IOException, TrustyUriException {
+        md = RdfHasher.getDigest();
+        r = new TrustyUriResource(file);
+        if (r.getArtifactCode() == null) {
+            logger.error("ERROR: Not a trusty URI or unknown module");
+            System.exit(1);
+        }
+        String moduleId = r.getModuleId();
+        if (!moduleId.equals(RdfModule.MODULE_ID)) {
+            logger.error("ERROR: Unsupported module: {} (this function only supports " + RdfModule.MODULE_ID + ")", moduleId);
+            System.exit(1);
+        }
+        RDFFormat format = r.getFormat(RDFFormat.TURTLE);
 
-			@Override
-			public void handleStatement(Statement st) throws RDFHandlerException {
-				if (previous != null && StatementComparator.compareStatement(previous, st) > 0) {
-					throw new RuntimeException("File not sorted");
-				}
-				if (!st.equals(previous)) {
-					RdfHasher.digest(st, md);
-				}
-				previous = st;
-			}
+        RDFParser p = RdfUtils.getParser(format);
+        previous = null;
+        p.setRDFHandler(new RdfPreprocessor(new AbstractRDFHandler() {
 
-		}, r.getArtifactCode()));
-		BufferedReader reader = new BufferedReader(r.getInputStreamReader(), 64*1024);
-		try {
-			p.parse(reader, "");
-		} catch (RDF4JException ex) {
-			throw new TrustyUriException(ex);
-		} finally {
-			reader.close();
-		}
+            @Override
+            public void handleStatement(Statement st) throws RDFHandlerException {
+                if (previous != null && StatementComparator.compareStatement(previous, st) > 0) {
+                    throw new RuntimeException("File not sorted");
+                }
+                if (!st.equals(previous)) {
+                    RdfHasher.digest(st, md);
+                }
+                previous = st;
+            }
 
-		String artifactCode = RdfHasher.getArtifactCode(md);
-		return artifactCode.equals(r.getArtifactCode());
-	}
+        }, r.getArtifactCode()));
+        BufferedReader reader = new BufferedReader(r.getInputStreamReader(), 64 * 1024);
+        try {
+            p.parse(reader, "");
+        } catch (RDF4JException ex) {
+            throw new TrustyUriException(ex);
+        } finally {
+            reader.close();
+        }
 
-	public String getArtifactCode() {
-		return r.getArtifactCode();
-	}
+        String artifactCode = RdfHasher.getArtifactCode(md);
+        return artifactCode.equals(r.getArtifactCode());
+    }
+
+    public String getArtifactCode() {
+        return r.getArtifactCode();
+    }
 
 }


### PR DESCRIPTION
This pull request introduces Maven wrapper scripts and updates the build workflow to enable consistent Maven builds and testing across environments. It also updates several dependencies in `pom.xml` and improves logging in the `CheckFile` class by switching from `System.out.println` to SLF4J. The most important changes are grouped below:

Maven build and workflow enhancements:

* Added Maven wrapper files: `mvnw`, `mvnw.cmd`, and `.mvn/wrapper/maven-wrapper.properties`, enabling reproducible builds without requiring Maven pre-installed. [[1]](diffhunk://#diff-71e4d281385254628e2f465d531483e29749cb5f970a14b177707285acf3478aR1-R295) [[2]](diffhunk://#diff-64a82735d638ae1f0f66748c12366c49ab809d2a3efb6e99c451cace0f1c968cR1-R189) [[3]](diffhunk://#diff-1df564955cac198c2a317aceb01d86891160f1b185d9875b384b7d54819af358R1-R3)
* Introduced a new GitHub Actions workflow `.github/workflows/maven-test.yml` for automated testing across Java versions 21, 23, and 25.

Dependency updates in `pom.xml`:

* Updated `commons-io` to 2.21.0, `org.slf4j` to 2.0.17, and `commons-lang3` to 3.20.0; changed `slf4j-simple` scope to `test` for improved dependency management and compatibility. [[1]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L47-R59) [[2]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L98-R99)

Logging improvements:

* Replaced `System.out.println` with SLF4J logging in `CheckFile.java` for better log handling and consistency; added logger initialization. [[1]](diffhunk://#diff-565be66907e7788c74e8d4d44151ee4580aa2ca3b98f10f69c0b471e9e20bc9eR3-R5) [[2]](diffhunk://#diff-565be66907e7788c74e8d4d44151ee4580aa2ca3b98f10f69c0b471e9e20bc9eR18-R19) [[3]](diffhunk://#diff-565be66907e7788c74e8d4d44151ee4580aa2ca3b98f10f69c0b471e9e20bc9eL44-R52)