### PR TITLE
chore(deps): update rdf4j, jakarta.xml.bind-api, externalsortinginjava

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <maven.compiler.source>21</maven.compiler.source>
     <maven.compiler.target>21</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <rdf4j.version>5.1.4</rdf4j.version>
+    <rdf4j.version>5.3.0</rdf4j.version>
   </properties>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@
     <dependency>
       <groupId>com.google.code.externalsortinginjava</groupId>
       <artifactId>externalsortinginjava</artifactId>
-      <version>0.6.2</version>
+      <version>0.6.6</version>
     </dependency>
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     <dependency>
       <groupId>jakarta.xml.bind</groupId>
       <artifactId>jakarta.xml.bind-api</artifactId>
-      <version>4.0.2</version>
+      <version>4.0.5</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>


### PR DESCRIPTION
## Summary
- Bump `org.eclipse.rdf4j:*` 5.1.4 → 5.3.0
- Bump `jakarta.xml.bind:jakarta.xml.bind-api` 4.0.2 → 4.0.5
- Bump `com.google.code.externalsortinginjava` 0.6.2 → 0.6.6

Skipped pre-release upgrades (`jakarta.activation-api` 2.2.0-M2, `slf4j` 2.1.0-alpha1).

## Test plan
- [x] `./mvnw test` passes after each bump (29 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)